### PR TITLE
Prevent zero pixel ratio in renderer

### DIFF
--- a/src/photosphere-renderer.js
+++ b/src/photosphere-renderer.js
@@ -39,7 +39,8 @@ PhotosphereRenderer.prototype.init = function() {
   renderer.setSize(window.innerWidth, window.innerHeight);
 
   // Round down fractional DPR values for better performance.
-  renderer.setPixelRatio(Math.floor(window.devicePixelRatio));
+  var pixelRatio = window.devicePixelRatio < 1 ? 1 : Math.floor(window.devicePixelRatio)
+  renderer.setPixelRatio(pixelRatio);
   container.appendChild(renderer.domElement);
 
   var controls = new THREE.VRControls(camera);

--- a/src/photosphere-renderer.js
+++ b/src/photosphere-renderer.js
@@ -39,8 +39,7 @@ PhotosphereRenderer.prototype.init = function() {
   renderer.setSize(window.innerWidth, window.innerHeight);
 
   // Round down fractional DPR values for better performance.
-  var pixelRatio = window.devicePixelRatio < 1 ? 1 : Math.floor(window.devicePixelRatio)
-  renderer.setPixelRatio(pixelRatio);
+  renderer.setPixelRatio(Math.max(1, Math.floor(window.devicePixelRatio)));
   container.appendChild(renderer.domElement);
 
   var controls = new THREE.VRControls(camera);


### PR DESCRIPTION
... so that on browsers where page is zoomed out (zoom level less than 100%), the canvas dimension is not zero on page refresh. 

When the width and height of the canvas are zero on initialization, the loaded scene is black.