### PR TITLE
Dispose of HTMLVideoElements when changing scenes.

### DIFF
--- a/src/embed/adaptive-player.js
+++ b/src/embed/adaptive-player.js
@@ -67,6 +67,11 @@ AdaptivePlayer.prototype.load = function(url) {
   }
 };
 
+AdaptivePlayer.prototype.destroy = function() {
+  this.video.pause();
+  this.video.src = '';
+  this.video = null;
+};
 
 /*** PRIVATE API ***/
 

--- a/src/embed/main.js
+++ b/src/embed/main.js
@@ -149,6 +149,7 @@ function onSetContent(e) {
   worldRenderer.sphereRenderer.setOpacity(0, 500).then(function() {
     // Then load the new scene.
     var scene = SceneInfo.loadFromAPIParams(e.contentInfo);
+    worldRenderer.destroy();
     return worldRenderer.setScene(scene);
   }).then(function() {
     // Then fade the scene back in.

--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -116,18 +116,18 @@ WorldRenderer.prototype.setScene = function(scene) {
         this.didLoadFail_('Video is not supported on IE11.');
       }
     } else {
-      var player = new AdaptivePlayer();
-      player.on('load', function(videoElement) {
+      this.player = new AdaptivePlayer();
+      this.player.on('load', function(videoElement) {
         self.sphereRenderer.set360Video(videoElement, params).then(function() {
           self.didLoad_({videoElement: videoElement});
         });
       });
-      player.on('error', function(error) {
+      this.player.on('error', function(error) {
         self.didLoadFail_('Video load error: ' + error);
       });
-      player.load(scene.video);
+      this.player.load(scene.video);
 
-      this.videoProxy = new VideoProxy(player.video);
+      this.videoProxy = new VideoProxy(this.player.video);
     }
   }
 
@@ -140,6 +140,12 @@ WorldRenderer.prototype.setScene = function(scene) {
 WorldRenderer.prototype.isVRMode = function() {
   return !!this.vrDisplay && this.vrDisplay.isPresenting;
 };
+
+WorldRenderer.prototype.destroy = function() {
+  this.player.removeAllListeners();
+  this.player.destroy();
+  this.player = null;
+}
 
 WorldRenderer.prototype.didLoad_ = function(opt_event) {
   var event = opt_event || {};


### PR DESCRIPTION
Ensure HTMLVideoElements are disposed in `AdaptivePlayer` when changing scenes with `WorldRenderer.setScene`, otherwise the previous videos will continue to load/run in the background.